### PR TITLE
Adding support for variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ Hover over a command to see information about the command and its parameters:
 
 ### Variable Definitions
 
-Variables are commonly included in Geant4 macros through the use of the `/control/alias [PARAMETER_NAME] [PARAMETER_VALUE]` command. This extension provides definition autocomplete of parameters which have been defined in the macro file. The type of the parameter where the variable is included is also considered.
+Variables are commonly included in Geant4 macros through the use of the `/control/alias [PARAMETER_NAME] [PARAMETER_VALUE]` command. This extension provides autocomplete of variables which have been defined in the macro file. The type of the parameter where the variable is included is also considered.
+
+The variables can also be renamed using the `F2` key or by right-clicking on the variable and selecting `Rename Symbol`. The definition of the variable can also be found by clicking on the variable and selecting `Go to Definition` or by clicking the variable name while holding `Ctrl`:
+
+![Renaming](images/rename.gif)
 
 _Note: this extension does not currently support autocomplete for variables which are not defined in the current document, such as those used in `/control/foreach` or `/control/loop`. This will be implemented in a future release._
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ Hover over a command to see information about the command and its parameters:
 
 ![Hover Information](images/hover.gif)
 
+### Variable Definitions
+
+Variables are commonly included in Geant4 macros through the use of the `/control/alias [PARAMETER_NAME] [PARAMETER_VALUE]` command. This extension provides definition autocomplete of parameters which have been defined in the macro file. The type of the parameter where the variable is included is also considered.
+
+_Note: this extension does not currently support autocomplete for variables which are not defined in the current document, such as those used in `/control/foreach` or `/control/loop`. This will be implemented in a future release._
 
 ## Feature Requests
 

--- a/images/rename.gif
+++ b/images/rename.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a5eb2feb6c594c916d0cb711fb6fa15f56f0e103b4cd90e21a00634094d7025
+size 154661

--- a/src/G4MacroDefinitionProvider.ts
+++ b/src/G4MacroDefinitionProvider.ts
@@ -1,0 +1,32 @@
+
+import * as vscode from 'vscode';
+import { Variable, g4macrocommands } from './g4macrocommands';
+
+export class G4MacroDefinitionProvider implements vscode.DefinitionProvider {
+
+    commands: g4macrocommands | undefined = undefined;
+
+    constructor(commands: g4macrocommands) {
+        this.commands = commands;
+    }
+
+    provideDefinition(
+        document: vscode.TextDocument, 
+        position: vscode.Position, 
+        token: vscode.CancellationToken)
+        : vscode.ProviderResult<vscode.Definition | vscode.DefinitionLink[]> {
+        const wordRange = document.getWordRangeAtPosition(position);
+        const word = document.getText(wordRange);
+
+        if (this.commands === undefined)
+            return undefined;
+
+        const variable = this.commands.getVariable(word);
+
+        if (variable === undefined)
+            return undefined;
+
+        return variable.location;
+    }
+
+}

--- a/src/G4MacroRenameProvider.ts
+++ b/src/G4MacroRenameProvider.ts
@@ -1,0 +1,172 @@
+
+import * as vscode from 'vscode';
+import { Variable, g4macrocommands } from './g4macrocommands';
+import { start } from 'repl';
+
+function getVariableRange(lineText: string, position: vscode.Position) : undefined | vscode.Range {
+    
+    let startIdx = position.character;
+    let endIdx = position.character;
+    let variableDefinition = false;
+
+    // Get the starting brace index
+    for (; startIdx >= 0; --startIdx) {
+        const char = lineText.at(startIdx);
+
+        if (char == ' ' || char == '\t') {
+            variableDefinition = true;
+            break;
+        }
+            
+        if (char == '{')
+            break;
+    }
+
+    // Get the ending brace index
+    for (; endIdx < lineText.length; ++endIdx) {
+
+        const char = lineText.at(endIdx);
+
+        if (char == ' ' || char == '\t') {
+            variableDefinition = true;
+            break;
+        }
+
+        if (char == '}')
+            break;
+    }
+
+    // If it is just the variable in braces, return the range
+    const range = new vscode.Range(
+        position.line,
+        startIdx + 1,
+        position.line,
+        endIdx
+    );
+
+    if (!variableDefinition)
+        return range;
+    
+    // Otherwise, check we are at the correct command
+    if (!lineText.startsWith('/control/alias'))
+        return undefined;
+    
+    // And check that we are the the correct parameter
+    const numberSpaces = lineText.substring(0, startIdx).split(/\s+/).length;
+
+    if (numberSpaces == 1)
+        return range;
+
+    return undefined;
+}
+
+export class G4MacroRenameProvider implements vscode.RenameProvider {
+
+    commands: g4macrocommands | undefined = undefined;
+    
+    constructor(commands: g4macrocommands) {
+        this.commands = commands;
+    }
+
+    provideRenameEdits(
+        document: vscode.TextDocument, 
+        position: vscode.Position,
+         newName: string, token: vscode.CancellationToken
+    ): vscode.ProviderResult<vscode.WorkspaceEdit> {
+        
+        const wordRange = document.getWordRangeAtPosition(position);
+        
+        if (!wordRange) {
+            return null;
+        }
+        
+        let word = document.getText(wordRange);
+
+        // Add braces to the start and end to replace
+        if (word.at(0) != '{')
+            word = "{" + word;
+
+        if (word.at(-1) != '}')
+            word = word + '}';
+
+        // Get the base word also
+        const baseWord = word.substring(1, word.length - 1);
+
+        const baseNewName = newName;
+        newName = "{" + baseNewName + "}";
+
+        // Define the regex for the variable substitutions
+        const bracedRegex = new RegExp(`${word}`, 'g');
+        const aliasRegex = new RegExp(`^/control/alias\\s+${baseWord}`, 'g');
+
+        // The proposed edit
+        const edit = new vscode.WorkspaceEdit();
+
+        for (let i = 0; i < document.lineCount; i++) {
+            
+            const line = document.lineAt(i);
+
+            // Replace the variable using regex
+            const newText = line.text.replace(bracedRegex, newName);
+            
+            if (newText !== line.text) {
+                edit.replace(document.uri, line.range, newText);
+            }
+
+            // Replace the definition if defined here
+            if (!line.text.startsWith('/control/alias'))
+                continue;
+
+            // Skip if not the correct parameter definition
+            const parameters = this.commands?.getInputParameters(line.text);
+
+            if (parameters == undefined || parameters[0].parameter != baseWord)
+                continue;
+
+            // Replace the variable with the new one
+            const aliasNewText = line.text.replace(aliasRegex, `/control/alias ${baseNewName}`);
+            
+            if (aliasNewText !== line.text) {
+                edit.replace(document.uri, line.range, aliasNewText);
+            }
+
+        }
+
+        // Force the update of diagnostics after the rename if available
+        if (this.commands?.diagnosticCollection != undefined)
+        this.commands?.refreshDiagnostics(
+            document,
+            this.commands.diagnosticCollection
+        );
+
+        return edit;
+        
+    }
+
+
+    prepareRename?(
+        document: vscode.TextDocument, 
+        position: vscode.Position, 
+        token: vscode.CancellationToken) : vscode.ProviderResult<vscode.Range | {
+        /**
+         * The range of the identifier that can be renamed.
+         */
+        range: vscode.Range;
+        /**
+         * The placeholder of the editors rename input box.
+         */
+        placeholder: string;
+    }> {
+
+        const lineText = document.lineAt(position.line).text;
+
+        const variableRange = getVariableRange(lineText, position);
+        
+        // If a valid range, return it
+        if (variableRange != undefined)
+            return variableRange;
+        
+        // Otherwise reject the proposed rename
+        return Promise.reject(new Error("Cannot rename this element!"));
+    }
+}

--- a/src/command_reader.ts
+++ b/src/command_reader.ts
@@ -13,6 +13,7 @@ interface Parameter {
 
 interface ICommand {
     command: string;
+    path: string;
     guidance: string;
     parameters: Parameter[];
     children: Map<string, Command>;
@@ -27,6 +28,7 @@ interface ICommand {
 export class Command implements ICommand {
     command: string = "";
     guidance: string = "";
+    path: string = "";
     parameters: Parameter[] = [];
     children: Map<string, Command> = new Map<string, Command>();
 
@@ -108,6 +110,7 @@ export class Command implements ICommand {
                     break;
 
                 nextCommand.command = path[i];
+                nextCommand.path = path.slice(0, i + 1).join("/");
             }
 
             thisCommand = nextCommand.children;
@@ -162,6 +165,7 @@ export class Command implements ICommand {
                 // Initialise the current command
                 currentCommand = new Command();
                 currentCommand.command = commandPathSplit[commandPathSplit.length - 1];
+                currentCommand.path = commandPath;
 
                 this.addCommand(commandPath, currentCommand);
             }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { g4macrocommands } from './g4macrocommands';
+import { G4MacroDefinitionProvider } from './G4MacroDefinitionProvider';
 
 export function activate(context: vscode.ExtensionContext) {
 
@@ -15,6 +16,11 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(typeDiagnostics);
 
 	commands.maintainDiagnostics(context, typeDiagnostics);
+
+	const definitionProvider = vscode.languages.registerDefinitionProvider(
+		'g4macro',
+		new G4MacroDefinitionProvider(commands)
+	);
 
 	const hoverProvider = vscode.languages.registerHoverProvider(
 		'g4macro',
@@ -151,7 +157,13 @@ export function activate(context: vscode.ExtensionContext) {
 		' '
 	);
 
-	context.subscriptions.push(completionsProvider, aliasProvider, signatureInfoProvider, codeActionProvider, hoverProvider);
+	context.subscriptions.push(
+		definitionProvider,
+		completionsProvider,
+		aliasProvider,
+		signatureInfoProvider,
+		codeActionProvider,
+		hoverProvider);
 
 	// Register the command to add addtional UI commands to the registry
 	context.subscriptions.push(vscode.commands.registerCommand('geant4-macro-extension.addCommandFile', () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,8 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import { g4macrocommands } from './g4macrocommands';
 import { G4MacroDefinitionProvider } from './G4MacroDefinitionProvider';
+import { G4MacroRenameProvider } from './G4MacroRenameProvider';
+import { rename } from 'fs';
 
 export function activate(context: vscode.ExtensionContext) {
 
@@ -20,6 +22,11 @@ export function activate(context: vscode.ExtensionContext) {
 	const definitionProvider = vscode.languages.registerDefinitionProvider(
 		'g4macro',
 		new G4MacroDefinitionProvider(commands)
+	);
+
+	const renameProvider = vscode.languages.registerRenameProvider(
+		'g4macro',
+		new G4MacroRenameProvider(commands)
 	);
 
 	const hoverProvider = vscode.languages.registerHoverProvider(
@@ -159,6 +166,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(
 		definitionProvider,
+		renameProvider,
 		completionsProvider,
 		aliasProvider,
 		signatureInfoProvider,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -123,6 +123,19 @@ export function activate(context: vscode.ExtensionContext) {
 		'/'
 	);
 
+	// Provide completions for the registers alias'
+	const aliasProvider = vscode.languages.registerCompletionItemProvider(
+		'g4macro',
+		{
+			provideCompletionItems() {
+
+				return commands.getVariableCompletions();
+
+			}
+		},
+		'{'
+	);
+
 	// Provide the function signatures for the UI calls
 	const signatureInfoProvider = vscode.languages.registerSignatureHelpProvider(
 		'g4macro',
@@ -138,7 +151,7 @@ export function activate(context: vscode.ExtensionContext) {
 		' '
 	);
 
-	context.subscriptions.push(completionsProvider, signatureInfoProvider, codeActionProvider, hoverProvider);
+	context.subscriptions.push(completionsProvider, aliasProvider, signatureInfoProvider, codeActionProvider, hoverProvider);
 
 	// Register the command to add addtional UI commands to the registry
 	context.subscriptions.push(vscode.commands.registerCommand('geant4-macro-extension.addCommandFile', () => {

--- a/src/g4macrocommands.ts
+++ b/src/g4macrocommands.ts
@@ -57,6 +57,7 @@ export class g4macrocommands {
     path: string = "";
     commands: Command = new Command();
     variables: Map<string, Variable> = new Map<string, Variable>();
+    diagnosticCollection: vscode.DiagnosticCollection | undefined = undefined;
 
     constructor(path: string) {
         this.path = path;
@@ -397,8 +398,6 @@ export class g4macrocommands {
 
         }
 
-        diagnosticCollection.set(doc.uri, diagnostics);
-
         this.variables = newVariables;
     }
 
@@ -464,6 +463,8 @@ export class g4macrocommands {
      * @param diagnosticCollection - The diagnostic collection to maintain.
      */
     public maintainDiagnostics(context: vscode.ExtensionContext, diagnosticCollection: vscode.DiagnosticCollection) {
+
+        this.diagnosticCollection = diagnosticCollection; 
 
         if (vscode.window.activeTextEditor) {
             this.refreshDiagnostics(vscode.window.activeTextEditor.document, diagnosticCollection);


### PR DESCRIPTION
1. Fixed type checking for variables as defined through /control/alias.
2. Implemented definition provider so that a variable definition can be found from its usage throughout the macro.
3. Added renaming support so that a variable can be consistently renamed throughout the macro.
4. Added autocomplete for when the braces are used.

Note that there is currently no support for variables defined in other scripts as this requires further thought.