### PR TITLE
Fixing missing diagnostics

### DIFF
--- a/src/g4macrocommands.ts
+++ b/src/g4macrocommands.ts
@@ -399,6 +399,8 @@ export class g4macrocommands {
         }
 
         this.variables = newVariables;
+
+        diagnosticCollection.set(doc.uri, diagnostics);
     }
 
     public fillVariableInString(toFill: string) : string {


### PR DESCRIPTION
Diagnostics were not correctly showing, fixed by updating the collection.